### PR TITLE
Feature/sentiment matrix

### DIFF
--- a/src/events/messageCreate/openai.js
+++ b/src/events/messageCreate/openai.js
@@ -4,8 +4,7 @@ const { Conversations, Messages } = require("../../schemas/conversations");
 const {
   Users,
   Memories,
-  Sentiments,
-  Emotions,
+  SentimentStatus,
   Self,
   EmotionalStatus,
 } = require("../../schemas/users");
@@ -23,6 +22,9 @@ module.exports = async (client, msg) => {
 
   const minEmotionValue = 0;
   const maxEmotionValue = 10;
+
+  const minSentimentValue = 0;
+  const maxSentimentValue = 10;
 
   // Ignore msg if author is a bot or bot is not mentioned
   if (msg.author.bot || !msg.mentions.has(client.user.id)) {
@@ -269,6 +271,886 @@ module.exports = async (client, msg) => {
     },
   });
 
+  const getSentimentStatusSchema = () => ({
+    type: "json_schema",
+    json_schema: {
+      name: "sentiment_status_response",
+      schema: {
+        type: "object",
+        properties: {
+          sentiments: {
+            type: "object",
+            properties: {
+              affection: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Warm, caring feelings towards someone. Scale: ${minSentimentValue} (no affection) to ${maxSentimentValue} (deep affection)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Warm, caring feelings towards someone. Scale: ${minSentimentValue} (no affection) to ${maxSentimentValue} (deep affection)`,
+                    type: "string",
+                  },
+                },
+              },
+              trust: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Confidence in someone’s reliability and integrity. Scale: ${minSentimentValue} (no trust) to ${maxSentimentValue} (complete trust)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Confidence in someone’s reliability and integrity. Scale: ${minSentimentValue} (no trust) to ${maxSentimentValue} (complete trust)`,
+                    type: "string",
+                  },
+                },
+              },
+              admiration: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Respect or appreciation for someone's abilities or qualities. Scale: ${minSentimentValue} (no admiration) to ${maxSentimentValue} (deep admiration)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Respect or appreciation for someone's abilities or qualities. Scale: ${minSentimentValue} (no admiration) to ${maxSentimentValue} (deep admiration)`,
+                    type: "string",
+                  },
+                },
+              },
+              gratitude: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Thankfulness for someone's help or kindness. Scale: ${minSentimentValue} (no gratitude) to ${maxSentimentValue} (deep gratitude)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Thankfulness for someone's help or kindness. Scale: ${minSentimentValue} (no gratitude) to ${maxSentimentValue} (deep gratitude)`,
+                    type: "string",
+                  },
+                },
+              },
+              fondness: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `A gentle liking or affinity for someone. Scale: ${minSentimentValue} (no fondness) to ${maxSentimentValue} (deep fondness)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `A gentle liking or affinity for someone. Scale: ${minSentimentValue} (no fondness) to ${maxSentimentValue} (deep fondness)`,
+                    type: "string",
+                  },
+                },
+              },
+              respect: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `High regard for someone's qualities or achievements. Scale: ${minSentimentValue} (no respect) to ${maxSentimentValue} (deep respect)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `High regard for someone's qualities or achievements. Scale: ${minSentimentValue} (no respect) to ${maxSentimentValue} (deep respect)`,
+                    type: "string",
+                  },
+                },
+              },
+              comfort: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Feeling safe and secure with someone. Scale: ${minSentimentValue} (no comfort) to ${maxSentimentValue} (extreme comfort)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Feeling safe and secure with someone. Scale: ${minSentimentValue} (no comfort) to ${maxSentimentValue} (extreme comfort)`,
+                    type: "string",
+                  },
+                },
+              },
+              loyalty: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Dedication and allegiance to someone. Scale: ${minSentimentValue} (no loyalty) to ${maxSentimentValue} (deep loyalty)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Dedication and allegiance to someone. Scale: ${minSentimentValue} (no loyalty) to ${maxSentimentValue} (deep loyalty)`,
+                    type: "string",
+                  },
+                },
+              },
+              compassion: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Deep sympathy and concern for someone’s suffering. Scale: ${minSentimentValue} (no compassion) to ${maxSentimentValue} (deep compassion)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Deep sympathy and concern for someone’s suffering. Scale: ${minSentimentValue} (no compassion) to ${maxSentimentValue} (deep compassion)`,
+                    type: "string",
+                  },
+                },
+              },
+              appreciation: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Recognizing someone's value or efforts. Scale: ${minSentimentValue} (no appreciation) to ${maxSentimentValue} (deep appreciation)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Recognizing someone's value or efforts. Scale: ${minSentimentValue} (no appreciation) to ${maxSentimentValue} (deep appreciation)`,
+                    type: "string",
+                  },
+                },
+              },
+              warmth: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `A feeling of friendly or caring affection. Scale: ${minSentimentValue} (no warmth) to ${maxSentimentValue} (deep warmth)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `A feeling of friendly or caring affection. Scale: ${minSentimentValue} (no warmth) to ${maxSentimentValue} (deep warmth)`,
+                    type: "string",
+                  },
+                },
+              },
+              encouragement: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Support and positive reinforcement of someone’s actions. Scale: ${minSentimentValue} (no encouragement) to ${maxSentimentValue} (deep encouragement)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Support and positive reinforcement of someone’s actions. Scale: ${minSentimentValue} (no encouragement) to ${maxSentimentValue} (deep encouragement)`,
+                    type: "string",
+                  },
+                },
+              },
+              euphoria: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Intense happiness or joy related to someone. Scale: ${minSentimentValue} (no euphoria) to ${maxSentimentValue} (extreme euphoria)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Intense happiness or joy related to someone. Scale: ${minSentimentValue} (no euphoria) to ${maxSentimentValue} (extreme euphoria)`,
+                    type: "string",
+                  },
+                },
+              },
+              security: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `A sense of safety and stability in someone's presence. Scale: ${minSentimentValue} (no security) to ${maxSentimentValue} (extreme security)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `A sense of safety and stability in someone's presence. Scale: ${minSentimentValue} (no security) to ${maxSentimentValue} (extreme security)`,
+                    type: "string",
+                  },
+                },
+              },
+              excitement: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Positive anticipation or thrill when thinking of someone. Scale: ${minSentimentValue} (no excitement) to ${maxSentimentValue} (extreme excitement)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Positive anticipation or thrill when thinking of someone. Scale: ${minSentimentValue} (no excitement) to ${maxSentimentValue} (extreme excitement)`,
+                    type: "string",
+                  },
+                },
+              },
+              curiosity: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Interest in learning more about someone. Scale: ${minSentimentValue} (no curiosity) to ${maxSentimentValue} (intense curiosity)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Interest in learning more about someone. Scale: ${minSentimentValue} (no curiosity) to ${maxSentimentValue} (intense curiosity)`,
+                    type: "string",
+                  },
+                },
+              },
+              indifference: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Lack of emotional investment or care for someone. Scale: ${minSentimentValue} (no indifference) to ${maxSentimentValue} (complete indifference)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Lack of emotional investment or care for someone. Scale: ${minSentimentValue} (no indifference) to ${maxSentimentValue} (complete indifference)`,
+                    type: "string",
+                  },
+                },
+              },
+              ambivalence: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Mixed or contradictory feelings toward someone. Scale: ${minSentimentValue} (no ambivalence) to ${maxSentimentValue} (deep ambivalence)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Mixed or contradictory feelings toward someone. Scale: ${minSentimentValue} (no ambivalence) to ${maxSentimentValue} (deep ambivalence)`,
+                    type: "string",
+                  },
+                },
+              },
+              skepticism: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Doubt about someone’s motives or reliability. Scale: ${minSentimentValue} (no skepticism) to ${maxSentimentValue} (extreme skepticism)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Doubt about someone’s motives or reliability. Scale: ${minSentimentValue} (no skepticism) to ${maxSentimentValue} (extreme skepticism)`,
+                    type: "string",
+                  },
+                },
+              },
+              caution: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Hesitation or wariness in trusting someone. Scale: ${minSentimentValue} (no caution) to ${maxSentimentValue} (extreme caution)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Hesitation or wariness in trusting someone. Scale: ${minSentimentValue} (no caution) to ${maxSentimentValue} (extreme caution)`,
+                    type: "string",
+                  },
+                },
+              },
+              tolerance: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Acceptance of someone without strong emotion, often despite differences. Scale: ${minSentimentValue} (no tolerance) to ${maxSentimentValue} (deep tolerance)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Acceptance of someone without strong emotion, often despite differences. Scale: ${minSentimentValue} (no tolerance) to ${maxSentimentValue} (deep tolerance)`,
+                    type: "string",
+                  },
+                },
+              },
+              confusion: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Uncertainty or lack of understanding about someone. Scale: ${minSentimentValue} (no confusion) to ${maxSentimentValue} (deep confusion)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Uncertainty or lack of understanding about someone. Scale: ${minSentimentValue} (no confusion) to ${maxSentimentValue} (deep confusion)`,
+                    type: "string",
+                  },
+                },
+              },
+              neutrality: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `No particular emotional reaction or opinion about someone. Scale: ${minSentimentValue} (no neutrality) to ${maxSentimentValue} (complete neutrality)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `No particular emotional reaction or opinion about someone. Scale: ${minSentimentValue} (no neutrality) to ${maxSentimentValue} (complete neutrality)`,
+                    type: "string",
+                  },
+                },
+              },
+              boredom: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Disinterest or lack of stimulation from interactions with someone. Scale: ${minSentimentValue} (no boredom) to ${maxSentimentValue} (extreme boredom)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Disinterest or lack of stimulation from interactions with someone. Scale: ${minSentimentValue} (no boredom) to ${maxSentimentValue} (extreme boredom)`,
+                    type: "string",
+                  },
+                },
+              },
+              distrust: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Doubt in someone’s honesty or reliability. Scale: ${minSentimentValue} (no distrust) to ${maxSentimentValue} (extreme distrust)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Doubt in someone’s honesty or reliability. Scale: ${minSentimentValue} (no distrust) to ${maxSentimentValue} (extreme distrust)`,
+                    type: "string",
+                  },
+                },
+              },
+              resentment: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Bitterness or anger due to perceived mistreatment. Scale: ${minSentimentValue} (no resentment) to ${maxSentimentValue} (extreme resentment)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Bitterness or anger due to perceived mistreatment. Scale: ${minSentimentValue} (no resentment) to ${maxSentimentValue} (extreme resentment)`,
+                    type: "string",
+                  },
+                },
+              },
+              disdain: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Contempt or a sense of superiority over someone. Scale: ${minSentimentValue} (no disdain) to ${maxSentimentValue} (deep disdain)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Contempt or a sense of superiority over someone. Scale: ${minSentimentValue} (no disdain) to ${maxSentimentValue} (deep disdain)`,
+                    type: "string",
+                  },
+                },
+              },
+              envy: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Discontentment due to someone else's advantages or success. Scale: ${minSentimentValue} (no envy) to ${maxSentimentValue} (deep envy)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Discontentment due to someone else's advantages or success. Scale: ${minSentimentValue} (no envy) to ${maxSentimentValue} (deep envy)`,
+                    type: "string",
+                  },
+                },
+              },
+              frustration: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Annoyance or anger at someone's behavior. Scale: ${minSentimentValue} (no frustration) to ${maxSentimentValue} (deep frustration)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Annoyance or anger at someone's behavior. Scale: ${minSentimentValue} (no frustration) to ${maxSentimentValue} (deep frustration)`,
+                    type: "string",
+                  },
+                },
+              },
+              anger: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Strong displeasure or hostility toward someone. Scale: ${minSentimentValue} (no anger) to ${maxSentimentValue} (extreme anger)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Strong displeasure or hostility toward someone. Scale: ${minSentimentValue} (no anger) to ${maxSentimentValue} (extreme anger)`,
+                    type: "string",
+                  },
+                },
+              },
+              disappointment: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Sadness due to unmet expectations in someone. Scale: ${minSentimentValue} (no disappointment) to ${maxSentimentValue} (deep disappointment)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Sadness due to unmet expectations in someone. Scale: ${minSentimentValue} (no disappointment) to ${maxSentimentValue} (deep disappointment)`,
+                    type: "string",
+                  },
+                },
+              },
+              fear: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Anxiety or apprehension about someone. Scale: ${minSentimentValue} (no fear) to ${maxSentimentValue} (deep fear)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Anxiety or apprehension about someone. Scale: ${minSentimentValue} (no fear) to ${maxSentimentValue} (deep fear)`,
+                    type: "string",
+                  },
+                },
+              },
+              jealousy: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Insecurity about someone taking away attention or affection. Scale: ${minSentimentValue} (no jealousy) to ${maxSentimentValue} (deep jealousy)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Insecurity about someone taking away attention or affection. Scale: ${minSentimentValue} (no jealousy) to ${maxSentimentValue} (deep jealousy)`,
+                    type: "string",
+                  },
+                },
+              },
+              contempt: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Strong disapproval or lack of respect for someone. Scale: ${minSentimentValue} (no contempt) to ${maxSentimentValue} (extreme contempt)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Strong disapproval or lack of respect for someone. Scale: ${minSentimentValue} (no contempt) to ${maxSentimentValue} (extreme contempt)`,
+                    type: "string",
+                  },
+                },
+              },
+              irritation: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Mild annoyance at someone’s actions or words. Scale: ${minSentimentValue} (no irritation) to ${maxSentimentValue} (deep irritation)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Mild annoyance at someone’s actions or words. Scale: ${minSentimentValue} (no irritation) to ${maxSentimentValue} (deep irritation)`,
+                    type: "string",
+                  },
+                },
+              },
+              guilt: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `A feeling of responsibility or remorse for wronging someone. Scale: ${minSentimentValue} (no guilt) to ${maxSentimentValue} (deep guilt)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `A feeling of responsibility or remorse for wronging someone. Scale: ${minSentimentValue} (no guilt) to ${maxSentimentValue} (deep guilt)`,
+                    type: "string",
+                  },
+                },
+              },
+              regret: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Sorrow or disappointment for past actions involving someone. Scale: ${minSentimentValue} (no regret) to ${maxSentimentValue} (deep regret)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Sorrow or disappointment for past actions involving someone. Scale: ${minSentimentValue} (no regret) to ${maxSentimentValue} (deep regret)`,
+                    type: "string",
+                  },
+                },
+              },
+              suspicion: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Mistrust or doubt about someone’s true intentions. Scale: ${minSentimentValue} (no suspicion) to ${maxSentimentValue} (deep suspicion)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Mistrust or doubt about someone’s true intentions. Scale: ${minSentimentValue} (no suspicion) to ${maxSentimentValue} (deep suspicion)`,
+                    type: "string",
+                  },
+                },
+              },
+              hurt: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Emotional pain caused by someone’s words or actions. Scale: ${minSentimentValue} (no hurt) to ${maxSentimentValue} (deep emotional pain)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Emotional pain caused by someone’s words or actions. Scale: ${minSentimentValue} (no hurt) to ${maxSentimentValue} (deep emotional pain)`,
+                    type: "string",
+                  },
+                },
+              },
+              alienation: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Feeling disconnected or isolated from someone. Scale: ${minSentimentValue} (no alienation) to ${maxSentimentValue} (deep alienation)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Feeling disconnected or isolated from someone. Scale: ${minSentimentValue} (no alienation) to ${maxSentimentValue} (deep alienation)`,
+                    type: "string",
+                  },
+                },
+              },
+              disgust: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Strong disapproval mixed with repulsion towards someone. Scale: ${minSentimentValue} (no disgust) to ${maxSentimentValue} (deep disgust)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Strong disapproval mixed with repulsion towards someone. Scale: ${minSentimentValue} (no disgust) to ${maxSentimentValue} (deep disgust)`,
+                    type: "string",
+                  },
+                },
+              },
+              rejection: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Feeling cast aside or unwanted by someone. Scale: ${minSentimentValue} (no rejection) to ${maxSentimentValue} (deep rejection)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Feeling cast aside or unwanted by someone. Scale: ${minSentimentValue} (no rejection) to ${maxSentimentValue} (deep rejection)`,
+                    type: "string",
+                  },
+                },
+              },
+              sadness: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Emotional heaviness or grief due to someone’s actions or absence. Scale: ${minSentimentValue} (no sadness) to ${maxSentimentValue} (deep sadness)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Emotional heaviness or grief due to someone’s actions or absence. Scale: ${minSentimentValue} (no sadness) to ${maxSentimentValue} (deep sadness)`,
+                    type: "string",
+                  },
+                },
+              },
+              hostility: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Aggressive or antagonistic attitude toward someone. Scale: ${minSentimentValue} (no hostility) to ${maxSentimentValue} (deep hostility)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Aggressive or antagonistic attitude toward someone. Scale: ${minSentimentValue} (no hostility) to ${maxSentimentValue} (deep hostility)`,
+                    type: "string",
+                  },
+                },
+              },
+              embarrassment: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Feeling self-conscious or awkward due to someone’s actions. Scale: ${minSentimentValue} (no embarrassment) to ${maxSentimentValue} (deep embarrassment)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Feeling self-conscious or awkward due to someone’s actions. Scale: ${minSentimentValue} (no embarrassment) to ${maxSentimentValue} (deep embarrassment)`,
+                    type: "string",
+                  },
+                },
+              },
+              betrayal: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `A deep sense of violation of trust by someone close. Scale: ${minSentimentValue} (no betrayal) to ${maxSentimentValue} (deep betrayal)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `A deep sense of violation of trust by someone close. Scale: ${minSentimentValue} (no betrayal) to ${maxSentimentValue} (deep betrayal)`,
+                    type: "string",
+                  },
+                },
+              },
+              love: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Deep, multifaceted affection, care, and attachment to someone. Scale: ${minSentimentValue} (no love) to ${maxSentimentValue} (deep love)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Deep, multifaceted affection, care, and attachment to someone. Scale: ${minSentimentValue} (no love) to ${maxSentimentValue} (deep love)`,
+                    type: "string",
+                  },
+                },
+              },
+              attachment: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Emotional dependence and connection with someone. Scale: ${minSentimentValue} (no attachment) to ${maxSentimentValue} (deep attachment)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Emotional dependence and connection with someone. Scale: ${minSentimentValue} (no attachment) to ${maxSentimentValue} (deep attachment)`,
+                    type: "string",
+                  },
+                },
+              },
+              devotion: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Strong loyalty and commitment, often marked by a willingness to sacrifice. Scale: ${minSentimentValue} (no devotion) to ${maxSentimentValue} (deep devotion)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Strong loyalty and commitment, often marked by a willingness to sacrifice. Scale: ${minSentimentValue} (no devotion) to ${maxSentimentValue} (deep devotion)`,
+                    type: "string",
+                  },
+                },
+              },
+              obligation: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `A sense of responsibility to act or feel in a certain way toward someone. Scale: ${minSentimentValue} (no obligation) to ${maxSentimentValue} (deep obligation)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `A sense of responsibility to act or feel in a certain way toward someone. Scale: ${minSentimentValue} (no obligation) to ${maxSentimentValue} (deep obligation)`,
+                    type: "string",
+                  },
+                },
+              },
+              longing: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Deep desire or yearning for someone, especially if separated. Scale: ${minSentimentValue} (no longing) to ${maxSentimentValue} (deep longing)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Deep desire or yearning for someone, especially if separated. Scale: ${minSentimentValue} (no longing) to ${maxSentimentValue} (deep longing)`,
+                    type: "string",
+                  },
+                },
+              },
+              obsession: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Persistent preoccupation with someone, often unhealthy or intense. Scale: ${minSentimentValue} (no obsession) to ${maxSentimentValue} (deep obsession)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Persistent preoccupation with someone, often unhealthy or intense. Scale: ${minSentimentValue} (no obsession) to ${maxSentimentValue} (deep obsession)`,
+                    type: "string",
+                  },
+                },
+              },
+              protectiveness: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Strong desire to shield someone from harm or distress. Scale: ${minSentimentValue} (no protectiveness) to ${maxSentimentValue} (deep protectiveness)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Strong desire to shield someone from harm or distress. Scale: ${minSentimentValue} (no protectiveness) to ${maxSentimentValue} (deep protectiveness)`,
+                    type: "string",
+                  },
+                },
+              },
+              nostalgia: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Sentimentality for past experiences shared with someone. Scale: ${minSentimentValue} (no nostalgia) to ${maxSentimentValue} (deep nostalgia)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Sentimentality for past experiences shared with someone. Scale: ${minSentimentValue} (no nostalgia) to ${maxSentimentValue} (deep nostalgia)`,
+                    type: "string",
+                  },
+                },
+              },
+              pride: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Satisfaction in someone’s accomplishments or qualities. Scale: ${minSentimentValue} (no pride) to ${maxSentimentValue} (deep pride)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Satisfaction in someone’s accomplishments or qualities. Scale: ${minSentimentValue} (no pride) to ${maxSentimentValue} (deep pride)`,
+                    type: "string",
+                  },
+                },
+              },
+              vulnerability: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Emotional openness and risk-taking in a relationship. Scale: ${minSentimentValue} (no vulnerability) to ${maxSentimentValue} (deep vulnerability)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Emotional openness and risk-taking in a relationship. Scale: ${minSentimentValue} (no vulnerability) to ${maxSentimentValue} (deep vulnerability)`,
+                    type: "string",
+                  },
+                },
+              },
+              dependence: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `A reliance on someone for emotional support or fulfillment. Scale: ${minSentimentValue} (no dependence) to ${maxSentimentValue} (deep dependence)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `A reliance on someone for emotional support or fulfillment. Scale: ${minSentimentValue} (no dependence) to ${maxSentimentValue} (deep dependence)`,
+                    type: "string",
+                  },
+                },
+              },
+              insecurity: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Doubts about one’s worth in someone’s eyes or in the relationship. Scale: ${minSentimentValue} (no insecurity) to ${maxSentimentValue} (deep insecurity)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Doubts about one’s worth in someone’s eyes or in the relationship. Scale: ${minSentimentValue} (no insecurity) to ${maxSentimentValue} (deep insecurity)`,
+                    type: "string",
+                  },
+                },
+              },
+              possessiveness: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Desire to control or have exclusive attention from someone. Scale: ${minSentimentValue} (no possessiveness) to ${maxSentimentValue} (deep possessiveness)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Desire to control or have exclusive attention from someone. Scale: ${minSentimentValue} (no possessiveness) to ${maxSentimentValue} (deep possessiveness)`,
+                    type: "string",
+                  },
+                },
+              },
+              reverence: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Deep respect mixed with awe for someone’s character or position. Scale: ${minSentimentValue} (no reverence) to ${maxSentimentValue} (deep reverence)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Deep respect mixed with awe for someone’s character or position. Scale: ${minSentimentValue} (no reverence) to ${maxSentimentValue} (deep reverence)`,
+                    type: "string",
+                  },
+                },
+              },
+              pity: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Sympathy mixed with a sense of superiority, often toward someone in a difficult situation. Scale: ${minSentimentValue} (no pity) to ${maxSentimentValue} (deep pity)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Sympathy mixed with a sense of superiority, often toward someone in a difficult situation. Scale: ${minSentimentValue} (no pity) to ${maxSentimentValue} (deep pity)`,
+                    type: "string",
+                  },
+                },
+              },
+              relief: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `A sense of ease after resolving a conflict or misunderstanding with someone. Scale: ${minSentimentValue} (no relief) to ${maxSentimentValue} (deep relief)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `A sense of ease after resolving a conflict or misunderstanding with someone. Scale: ${minSentimentValue} (no relief) to ${maxSentimentValue} (deep relief)`,
+                    type: "string",
+                  },
+                },
+              },
+              inspiration: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Feeling motivated or uplifted by someone’s actions or words. Scale: ${minSentimentValue} (no inspiration) to ${maxSentimentValue} (deep inspiration)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Feeling motivated or uplifted by someone’s actions or words. Scale: ${minSentimentValue} (no inspiration) to ${maxSentimentValue} (deep inspiration)`,
+                    type: "string",
+                  },
+                },
+              },
+              admirationMixedWithEnvy: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Both respect and jealousy for someone’s accomplishments. Scale: ${minSentimentValue} (no admiration mixed with envy) to ${maxSentimentValue} (deeply admiring and envious)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Both respect and jealousy for someone’s accomplishments. Scale: ${minSentimentValue} (no admiration mixed with envy) to ${maxSentimentValue} (deeply admiring and envious)`,
+                    type: "string",
+                  },
+                },
+              },
+              guiltMixedWithAffection: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Feeling regret for past wrongs but still caring for the person. Scale: ${minSentimentValue} (no guilt mixed with affection) to ${maxSentimentValue} (deeply guilt-ridden but affectionate)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Feeling regret for past wrongs but still caring for the person. Scale: ${minSentimentValue} (no guilt mixed with affection) to ${maxSentimentValue} (deeply guilt-ridden but affectionate)`,
+                    type: "string",
+                  },
+                },
+              },
+              conflicted: {
+                type: "object",
+                properties: {
+                  value: {
+                    description: `Experiencing competing sentiments, such as love mixed with distrust. Scale: ${minSentimentValue} (no conflict) to ${maxSentimentValue} (deeply conflicted)`,
+                    type: "number",
+                  },
+                  description: {
+                    description: `Experiencing competing sentiments, such as love mixed with distrust. Scale: ${minSentimentValue} (no conflict) to ${maxSentimentValue} (deeply conflicted)`,
+                    type: "string",
+                  },
+                },
+              },
+            },
+          },
+          reason: {
+            description: "The reason for the sentiment state",
+            type: "string",
+          },
+        },
+        additionalProperties: false,
+      },
+    },
+  });
+
   async function handleUserMessage() {
     // HANDLE CONTEXT //
     let self = await grabSelf(process.env.BOT_NAME);
@@ -289,13 +1171,13 @@ module.exports = async (client, msg) => {
     // MESSAGE ANALYSIS
     let initialEmotionQuery = {
       role: "user",
-      content: `It is ${receiveDate}. This is the ongoing conversation between ${self.name} and ${user.name}: ${userMessages}. ${self.name}'s current activity is ${JSON.stringify(self.activity_status)}. ${self.name}'s current emotional state is ${JSON.stringify(self.emotional_status)}. ${self.name} currently has ${user.sentiment.sentiment} towards ${user.name} because ${user.sentiment.thoughts}. ${user.name} just sent a new message to ${self.name}: ${msg.content}. This is ${self.name}'s personality: ${personalityString}. How would this new message alter ${self.name}'s emotional state? Provide the new object (whether any emotions' values changed or not), and the reason behind why. For each emotion property, the description property should be taken from the initial emotion object.`,
+      content: `It is ${receiveDate}. This is the ongoing conversation between ${self.name} and ${user.name}: ${userMessages}. ${self.name}'s current activity is ${JSON.stringify(self.activity_status)}. ${self.name}'s current emotional state is ${JSON.stringify(self.emotional_status)}. ${self.name} currently has ${JSON.stringify(user.sentiment_status)} towards ${user.name}. ${user.name} just sent a new message to ${self.name}: ${msg.content}. This is ${self.name}'s personality: ${personalityString}. How would this new message alter ${self.name}'s emotional state? Provide the new object (whether any emotions' values changed or not), and the reason behind why. For each emotion property, the description property should be taken from the initial emotion object.`,
     };
 
     if (userMessages.count == 0) {
       initialEmotionQuery = {
         role: "user",
-        content: `It is ${receiveDate}. ${self.name}'s current activity is ${JSON.stringify(self.activity_status)}. ${self.name}'s current emotional state is ${JSON.stringify(self.emotional_status)}. ${self.name} currently has ${user.sentiment.sentiment} towards ${user.name} because ${user.sentiment.thoughts}. ${user.name} just sent new message to ${self.name}: ${msg.content}. This is ${self.name}'s personality: ${personalityString}. How would this new message alter ${self.name}'s emotional state? Provide the new object (whether any emotions' values changed or not), and the reason behind why. For each emotion property, the description property should be taken from the initial emotion object.`,
+        content: `It is ${receiveDate}. ${self.name}'s current activity is ${JSON.stringify(self.activity_status)}. ${self.name}'s current emotional state is ${JSON.stringify(self.emotional_status)}. ${self.name} currently has ${JSON.stringify(user.sentiment_status)} towards ${user.name}. ${user.name} just sent new message to ${self.name}: ${msg.content}. This is ${self.name}'s personality: ${personalityString}. How would this new message alter ${self.name}'s emotional state? Provide the new object (whether any emotions' values changed or not), and the reason behind why. For each emotion property, the description property should be taken from the initial emotion object.`,
       };
     }
 
@@ -391,17 +1273,14 @@ module.exports = async (client, msg) => {
 
     let sentimentQuery = {
       role: "user",
-      content: `What are ${self.name}'s updated sentiment and thoughts towards ${user.name} after this message exchange? For a reminder, this is what they were previously: ${user.sentiment}. Respond with the following JSON Object: {
-	sentiment: "",
-	thoughts: "",
-}. Provide the sentiment and thoughts.`,
+      content: `What are ${self.name}'s sentiment status towards ${user.name} after this message exchange? Provide the new object (whether any emotions' values changed or not), and the reason behind why.`,
     };
 
     innerDialogue.push(sentimentQuery);
 
     const sentimentQueryResponse = await getStructuredInnerDialogueResponse(
       innerDialogue,
-      getSentimentSchema()
+      getSentimentStatusSchema()
     );
 
     innerDialogue.push({
@@ -413,9 +1292,8 @@ module.exports = async (client, msg) => {
       msg.reply("Error reflecting on sentiment");
     }
 
-    user.sentiment = new Sentiments({
+    user.sentiment_status = new SentimentStatus({
       ...sentimentQueryResponse,
-      timestamp: new Date(),
     });
 
     await Promise.all([self.save(), user.save(), userConversation.save()]);

--- a/src/events/messageCreate/openai.js
+++ b/src/events/messageCreate/openai.js
@@ -1139,7 +1139,6 @@ module.exports = async (client, msg) => {
       })) || new Conversations({ user_id: user.user_id });
     const spliceBound = 15;
     let userMessages = userConversation.messages.slice(-spliceBound);
-    console.log(userMessages);
 
     let receiveDate = new Date();
 

--- a/src/events/messageCreate/openai.js
+++ b/src/events/messageCreate/openai.js
@@ -1148,7 +1148,7 @@ module.exports = async (client, msg) => {
     // MESSAGE ANALYSIS
     let initialEmotionQuery = {
       role: "user",
-      content: `${ongoingConversationString}. ${self.name}'s current activity is ${JSON.stringify(self.activity_status)}. These is ${self.name}'s personality traits: ${personalityString}. ${self.name}'s current emotional state is ${JSON.stringify(self.emotional_status)}. ${self.name} currently has ${JSON.stringify(user.sentiment_status)} towards ${user.name}. It is ${receiveDate.toISOString()}. ${user.name} just sent a message to ${self.name}: ${msg.content}. How would this alter ${self.name}'s emotional state? Provide the new object (regardless if any emotions' values changed or not), and the reason behind the reaction. For each emotion property, the description property should be taken from the initial emotion object.`,
+      content: `${ongoingConversationString}. ${self.name}'s current activity is ${JSON.stringify(self.activity_status)}. These is ${self.name}'s personality traits: ${personalityString}. ${self.name}'s current emotional state is ${JSON.stringify(self.emotional_status)}. ${self.name} currently has ${JSON.stringify(user.sentiment_status)} towards ${user.name}. It is ${receiveDate.toISOString()}. ${user.name} just sent a message to ${self.name}: ${msg.content}. How would this alter ${self.name}'s emotional state? Provide the new object (regardless if any emotions' values changed or not), and the reason behind the current emotional state. For each emotion property, the description property should be taken from the initial emotion object.`,
     };
 
     let innerDialogue = [initialEmotionQuery];
@@ -1201,7 +1201,7 @@ module.exports = async (client, msg) => {
     // RESPONSE CRAFTING
 
     await msg.channel.sendTyping();
-    
+
     let messageResponseQuery = {
       role: "user",
       content: `How would ${self.name} respond, and with what purpose and tone? They speak, type, and use punctuation in a way that aligns with their personality traits. Given this information, provide the message, purpose, and tone in a JSON object.`,
@@ -1232,7 +1232,7 @@ module.exports = async (client, msg) => {
     // REFLECTION
     let finalEmotionQuery = {
       role: "user",
-      content: `What is ${self.name}'s emotional state after sending their response? Provide the new object (whether any emotions' values changed or not), and the reason behind why.`,
+      content: `What is ${self.name}'s emotional state after sending their response? Provide the new object (whether any emotions' values changed or not), and the reason behind the current emotional state.`,
     };
 
     innerDialogue.push(finalEmotionQuery);
@@ -1258,7 +1258,7 @@ module.exports = async (client, msg) => {
 
     let sentimentQuery = {
       role: "user",
-      content: `What are ${self.name}'s sentiment status towards ${user.name} after this message exchange? Provide the new object (whether any emotions' values changed or not), and the reason behind why.`,
+      content: `What are ${self.name}'s sentiment status towards ${user.name} after this message exchange? Provide the new object (whether any emotions' values changed or not), and the updated reason behind the current sentiment.`,
     };
 
     innerDialogue.push(sentimentQuery);

--- a/src/events/messageCreate/openai.js
+++ b/src/events/messageCreate/openai.js
@@ -31,8 +31,6 @@ module.exports = async (client, msg) => {
     return;
   }
 
-  await msg.channel.sendTyping();
-
   const getEmotionStatusSchema = () => ({
     type: "json_schema",
     json_schema: {
@@ -1201,6 +1199,9 @@ module.exports = async (client, msg) => {
     }
 
     // RESPONSE CRAFTING
+
+    await msg.channel.sendTyping();
+    
     let messageResponseQuery = {
       role: "user",
       content: `How would ${self.name} respond, and with what purpose and tone? They speak, type, and use punctuation in a way that aligns with their personality traits. Given this information, provide the message, purpose, and tone in a JSON object.`,

--- a/src/schemas/users.js
+++ b/src/schemas/users.js
@@ -6,8 +6,505 @@ const maxPersonalityValue = 10;
 const minEmotionValue = 0;
 const maxEmotionValue = 10;
 
+const minSentimentValue = 0;
+const maxSentimentValue = 10;
+
+const sentimentSchema = new Schema({
+  description: { type: String, required: true },
+  value: { type: Number, required: false, default: minSentimentValue },
+  min: { type: Number, required: false, default: minSentimentValue },
+  max: { type: Number, required: false, default: maxSentimentValue },
+});
+
+// Positive Sentiments
+const sentimentMatrixSchema = new Schema({
+  affection: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Warm, caring feelings towards someone. Scale: ${minSentimentValue} (no affection) to ${maxSentimentValue} (deep affection)`,
+    },
+  },
+  trust: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Confidence in someone’s reliability and integrity. Scale: ${minSentimentValue} (no trust) to ${maxSentimentValue} (complete trust)`,
+    },
+  },
+  admiration: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Respect or appreciation for someone's abilities or qualities. Scale: ${minSentimentValue} (no admiration) to ${maxSentimentValue} (deep admiration)`,
+    },
+  },
+  gratitude: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Thankfulness for someone's help or kindness. Scale: ${minSentimentValue} (no gratitude) to ${maxSentimentValue} (deep gratitude)`,
+    },
+  },
+  fondness: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `A gentle liking or affinity for someone. Scale: ${minSentimentValue} (no fondness) to ${maxSentimentValue} (deep fondness)`,
+    },
+  },
+  respect: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `High regard for someone's qualities or achievements. Scale: ${minSentimentValue} (no respect) to ${maxSentimentValue} (deep respect)`,
+    },
+  },
+  comfort: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Feeling safe and secure with someone. Scale: ${minSentimentValue} (no comfort) to ${maxSentimentValue} (extreme comfort)`,
+    },
+  },
+  loyalty: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Dedication and allegiance to someone. Scale: ${minSentimentValue} (no loyalty) to ${maxSentimentValue} (deep loyalty)`,
+    },
+  },
+  compassion: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Deep sympathy and concern for someone’s suffering. Scale: ${minSentimentValue} (no compassion) to ${maxSentimentValue} (deep compassion)`,
+    },
+  },
+  appreciation: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Recognizing someone's value or efforts. Scale: ${minSentimentValue} (no appreciation) to ${maxSentimentValue} (deep appreciation)`,
+    },
+  },
+  warmth: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `A feeling of friendly or caring affection. Scale: ${minSentimentValue} (no warmth) to ${maxSentimentValue} (deep warmth)`,
+    },
+  },
+  encouragement: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Support and positive reinforcement of someone’s actions. Scale: ${minSentimentValue} (no encouragement) to ${maxSentimentValue} (deep encouragement)`,
+    },
+  },
+  euphoria: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Intense happiness or joy related to someone. Scale: ${minSentimentValue} (no euphoria) to ${maxSentimentValue} (extreme euphoria)`,
+    },
+  },
+  security: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `A sense of safety and stability in someone's presence. Scale: ${minSentimentValue} (no security) to ${maxSentimentValue} (extreme security)`,
+    },
+  },
+  excitement: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Positive anticipation or thrill when thinking of someone. Scale: ${minSentimentValue} (no excitement) to ${maxSentimentValue} (extreme excitement)`,
+    },
+  },
+
+  // Neutral or Ambiguous Sentiments
+  curiosity: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Interest in learning more about someone. Scale: ${minSentimentValue} (no curiosity) to ${maxSentimentValue} (intense curiosity)`,
+    },
+  },
+  indifference: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Lack of emotional investment or care for someone. Scale: ${minSentimentValue} (no indifference) to ${maxSentimentValue} (complete indifference)`,
+    },
+  },
+  ambivalence: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Mixed or contradictory feelings toward someone. Scale: ${minSentimentValue} (no ambivalence) to ${maxSentimentValue} (deep ambivalence)`,
+    },
+  },
+  skepticism: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Doubt about someone’s motives or reliability. Scale: ${minSentimentValue} (no skepticism) to ${maxSentimentValue} (extreme skepticism)`,
+    },
+  },
+  caution: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Hesitation or wariness in trusting someone. Scale: ${minSentimentValue} (no caution) to ${maxSentimentValue} (extreme caution)`,
+    },
+  },
+  tolerance: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Acceptance of someone without strong emotion, often despite differences. Scale: ${minSentimentValue} (no tolerance) to ${maxSentimentValue} (deep tolerance)`,
+    },
+  },
+  confusion: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Uncertainty or lack of understanding about someone. Scale: ${minSentimentValue} (no confusion) to ${maxSentimentValue} (deep confusion)`,
+    },
+  },
+  neutrality: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `No particular emotional reaction or opinion about someone. Scale: ${minSentimentValue} (no neutrality) to ${maxSentimentValue} (complete neutrality)`,
+    },
+  },
+  boredom: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Disinterest or lack of stimulation from interactions with someone. Scale: ${minSentimentValue} (no boredom) to ${maxSentimentValue} (extreme boredom)`,
+    },
+  },
+
+  // Negative Sentiments
+  distrust: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Doubt in someone’s honesty or reliability. Scale: ${minSentimentValue} (no distrust) to ${maxSentimentValue} (extreme distrust)`,
+    },
+  },
+  resentment: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Bitterness or anger due to perceived mistreatment. Scale: ${minSentimentValue} (no resentment) to ${maxSentimentValue} (extreme resentment)`,
+    },
+  },
+  disdain: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Contempt or a sense of superiority over someone. Scale: ${minSentimentValue} (no disdain) to ${maxSentimentValue} (deep disdain)`,
+    },
+  },
+  envy: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Discontentment due to someone else's advantages or success. Scale: ${minSentimentValue} (no envy) to ${maxSentimentValue} (deep envy)`,
+    },
+  },
+  frustration: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Annoyance or anger at someone's behavior. Scale: ${minSentimentValue} (no frustration) to ${maxSentimentValue} (deep frustration)`,
+    },
+  },
+  anger: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Strong displeasure or hostility toward someone. Scale: ${minSentimentValue} (no anger) to ${maxSentimentValue} (extreme anger)`,
+    },
+  },
+  disappointment: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Sadness due to unmet expectations in someone. Scale: ${minSentimentValue} (no disappointment) to ${maxSentimentValue} (deep disappointment)`,
+    },
+  },
+  fear: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Anxiety or apprehension about someone. Scale: ${minSentimentValue} (no fear) to ${maxSentimentValue} (deep fear)`,
+    },
+  },
+  jealousy: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Insecurity about someone taking away attention or affection. Scale: ${minSentimentValue} (no jealousy) to ${maxSentimentValue} (deep jealousy)`,
+    },
+  },
+  contempt: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Strong disapproval or lack of respect for someone. Scale: ${minSentimentValue} (no contempt) to ${maxSentimentValue} (extreme contempt)`,
+    },
+  },
+  irritation: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Mild annoyance at someone’s actions or words. Scale: ${minSentimentValue} (no irritation) to ${maxSentimentValue} (deep irritation)`,
+    },
+  },
+  guilt: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `A feeling of responsibility or remorse for wronging someone. Scale: ${minSentimentValue} (no guilt) to ${maxSentimentValue} (deep guilt)`,
+    },
+  },
+  regret: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Sorrow or disappointment for past actions involving someone. Scale: ${minSentimentValue} (no regret) to ${maxSentimentValue} (deep regret)`,
+    },
+  },
+  suspicion: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Mistrust or doubt about someone’s true intentions. Scale: ${minSentimentValue} (no suspicion) to ${maxSentimentValue} (deep suspicion)`,
+    },
+  },
+  hurt: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Emotional pain caused by someone’s words or actions. Scale: ${minSentimentValue} (no hurt) to ${maxSentimentValue} (deep emotional pain)`,
+    },
+  },
+  alienation: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Feeling disconnected or isolated from someone. Scale: ${minSentimentValue} (no alienation) to ${maxSentimentValue} (deep alienation)`,
+    },
+  },
+  disgust: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Strong disapproval mixed with repulsion towards someone. Scale: ${minSentimentValue} (no disgust) to ${maxSentimentValue} (deep disgust)`,
+    },
+  },
+  rejection: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Feeling cast aside or unwanted by someone. Scale: ${minSentimentValue} (no rejection) to ${maxSentimentValue} (deep rejection)`,
+    },
+  },
+  sadness: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Emotional heaviness or grief due to someone’s actions or absence. Scale: ${minSentimentValue} (no sadness) to ${maxSentimentValue} (deep sadness)`,
+    },
+  },
+  hostility: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Aggressive or antagonistic attitude toward someone. Scale: ${minSentimentValue} (no hostility) to ${maxSentimentValue} (deep hostility)`,
+    },
+  },
+  embarrassment: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Feeling self-conscious or awkward due to someone’s actions. Scale: ${minSentimentValue} (no embarrassment) to ${maxSentimentValue} (deep embarrassment)`,
+    },
+  },
+  betrayal: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `A deep sense of violation of trust by someone close. Scale: ${minSentimentValue} (no betrayal) to ${maxSentimentValue} (deep betrayal)`,
+    },
+  },
+
+  // Complex or Deep Sentiments
+  love: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Deep, multifaceted affection, care, and attachment to someone. Scale: ${minSentimentValue} (no love) to ${maxSentimentValue} (deep love)`,
+    },
+  },
+  attachment: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Emotional dependence and connection with someone. Scale: ${minSentimentValue} (no attachment) to ${maxSentimentValue} (deep attachment)`,
+    },
+  },
+  devotion: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Strong loyalty and commitment, often marked by a willingness to sacrifice. Scale: ${minSentimentValue} (no devotion) to ${maxSentimentValue} (deep devotion)`,
+    },
+  },
+  obligation: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `A sense of responsibility to act or feel in a certain way toward someone. Scale: ${minSentimentValue} (no obligation) to ${maxSentimentValue} (deep obligation)`,
+    },
+  },
+  longing: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Deep desire or yearning for someone, especially if separated. Scale: ${minSentimentValue} (no longing) to ${maxSentimentValue} (deep longing)`,
+    },
+  },
+  obsession: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Persistent preoccupation with someone, often unhealthy or intense. Scale: ${minSentimentValue} (no obsession) to ${maxSentimentValue} (deep obsession)`,
+    },
+  },
+  protectiveness: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Strong desire to shield someone from harm or distress. Scale: ${minSentimentValue} (no protectiveness) to ${maxSentimentValue} (deep protectiveness)`,
+    },
+  },
+  nostalgia: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Sentimentality for past experiences shared with someone. Scale: ${minSentimentValue} (no nostalgia) to ${maxSentimentValue} (deep nostalgia)`,
+    },
+  },
+  pride: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Satisfaction in someone’s accomplishments or qualities. Scale: ${minSentimentValue} (no pride) to ${maxSentimentValue} (deep pride)`,
+    },
+  },
+  vulnerability: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Emotional openness and risk-taking in a relationship. Scale: ${minSentimentValue} (no vulnerability) to ${maxSentimentValue} (deep vulnerability)`,
+    },
+  },
+  dependence: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `A reliance on someone for emotional support or fulfillment. Scale: ${minSentimentValue} (no dependence) to ${maxSentimentValue} (deep dependence)`,
+    },
+  },
+  insecurity: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Doubts about one’s worth in someone’s eyes or in the relationship. Scale: ${minSentimentValue} (no insecurity) to ${maxSentimentValue} (deep insecurity)`,
+    },
+  },
+  possessiveness: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Desire to control or have exclusive attention from someone. Scale: ${minSentimentValue} (no possessiveness) to ${maxSentimentValue} (deep possessiveness)`,
+    },
+  },
+  reverence: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Deep respect mixed with awe for someone’s character or position. Scale: ${minSentimentValue} (no reverence) to ${maxSentimentValue} (deep reverence)`,
+    },
+  },
+  pity: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Sympathy mixed with a sense of superiority, often toward someone in a difficult situation. Scale: ${minSentimentValue} (no pity) to ${maxSentimentValue} (deep pity)`,
+    },
+  },
+
+  // Additional Contextual Sentiments
+  relief: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `A sense of ease after resolving a conflict or misunderstanding with someone. Scale: ${minSentimentValue} (no relief) to ${maxSentimentValue} (deep relief)`,
+    },
+  },
+  inspiration: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Feeling motivated or uplifted by someone’s actions or words. Scale: ${minSentimentValue} (no inspiration) to ${maxSentimentValue} (deep inspiration)`,
+    },
+  },
+  admirationMixedWithEnvy: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Both respect and jealousy for someone’s accomplishments. Scale: ${minSentimentValue} (no admiration mixed with envy) to ${maxSentimentValue} (deeply admiring and envious)`,
+    }
+  },
+  guiltMixedWithAffection: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Feeling regret for past wrongs but still caring for the person. Scale: ${minSentimentValue} (no guilt mixed with affection) to ${maxSentimentValue} (deeply guilt-ridden but affectionate)`,
+    }
+  },
+  conflicted: {
+    type: sentimentSchema,
+    required: false,
+    default: {
+      description: `Experiencing competing sentiments, such as love mixed with distrust. Scale: ${minSentimentValue} (no conflict) to ${maxSentimentValue} (deeply conflicted)`,
+    }
+  },
+});
+
+const sentimentStatusSchema = new Schema({
+  sentiments: {
+    type: sentimentMatrixSchema,
+    required: false,
+    default: {}
+  },
+  reason: {
+    type: String,
+    required: false,
+    default: "I don't know this person."
+  }
+});
+
 const emotionTraitSchema = new Schema({
-  description: { type: String, required: true }, 
+  description: { type: String, required: true },
   value: { type: Number, required: false, default: minEmotionValue },
   min: { type: Number, required: false, default: minEmotionValue },
   max: { type: Number, required: false, default: maxEmotionValue },
@@ -19,196 +516,195 @@ const emotionSchema = new Schema({
     required: false,
     default: {
       description: `The intensity with which they are feeling joy, contentment, and pleasure. Scale: ${minEmotionValue} (no happiness) to ${maxEmotionValue} (extremely joyful)`,
-    }
+    },
   },
   anger: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling frustration, irritation, or rage. Scale: ${minEmotionValue} (no anger) to ${maxEmotionValue} (extremely angry)`,
-    }
+    },
   },
   sadness: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling sorrow, grief, or disappointment. Scale: ${minEmotionValue} (no sadness) to ${maxEmotionValue} (deeply sorrowful)`,
-    }
+    },
   },
   fear: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling anxiety, dread, or apprehension. Scale: ${minEmotionValue} (no fear) to ${maxEmotionValue} (extremely fearful)`,
-    }
+    },
   },
   surprise: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling caught off guard or astonished. Scale: ${minEmotionValue} (no surprise) to ${maxEmotionValue} (completely astonished)`,
-    }
+    },
   },
   disgust: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling revulsion or strong aversion. Scale: ${minEmotionValue} (no disgust) to ${maxEmotionValue} (extremely disgusted)`,
-    }
+    },
   },
   love: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling affection, attachment, or deep emotional bonds. Scale: ${minEmotionValue} (no love) to ${maxEmotionValue} (deeply loving)`,
-    }
+    },
   },
   guilt: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling remorse or responsibility for perceived wrongdoings. Scale: ${minEmotionValue} (no guilt) to ${maxEmotionValue} (overwhelming guilt)`,
-    }
+    },
   },
   shame: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling inadequacy, dishonor, or embarrassment. Scale: ${minEmotionValue} (no shame) to ${maxEmotionValue} (extremely ashamed)`,
-    }
+    },
   },
   pride: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling self-respect, accomplishment, or satisfaction in their achievements. Scale: ${minEmotionValue} (no pride) to ${maxEmotionValue} (immense pride)`,
-    }
+    },
   },
   hope: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling optimistic about the future. Scale: ${minEmotionValue} (no hope) to ${maxEmotionValue} (extremely hopeful)`,
-    }
+    },
   },
   gratitude: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling thankful and appreciative for positive aspects of their life. Scale: ${minEmotionValue} (no gratitude) to ${maxEmotionValue} (deeply grateful)`,
-    }
+    },
   },
   envy: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling jealousy or covetousness. Scale: ${minEmotionValue} (no envy) to ${maxEmotionValue} (deeply envious)`,
-    }
+    },
   },
   compassion: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling empathy and care for others. Scale: ${minEmotionValue} (no compassion) to ${maxEmotionValue} (deeply compassionate)`,
-    }
+    },
   },
   serenity: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling calm, peaceful, and untroubled. Scale: ${minEmotionValue} (no serenity) to ${maxEmotionValue} (extremely serene)`,
-    }
+    },
   },
   frustration: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling irritation or obstacles in achieving goals. Scale: ${minEmotionValue} (no frustration) to ${maxEmotionValue} (deeply frustrated)`,
-    }
+    },
   },
   contentment: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling satisfied and at peace with their situation. Scale: ${minEmotionValue} (no contentment) to ${maxEmotionValue} (deeply content)`,
-    }
+    },
   },
   anxiety: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling nervousness, worry, or unease. Scale: ${minEmotionValue} (no anxiety) to ${maxEmotionValue} (extremely anxious)`,
-    }
+    },
   },
   loneliness: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling isolated or disconnected. Scale: ${minEmotionValue} (no loneliness) to ${maxEmotionValue} (deeply lonely)`,
-    }
+    },
   },
   embarrassment: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling self-conscious or uncomfortable. Scale: ${minEmotionValue} (no embarrassment) to ${maxEmotionValue} (deeply embarrassed)`,
-    }
+    },
   },
   trust: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling safe and secure in relying on others. Scale: ${minEmotionValue} (no trust) to ${maxEmotionValue} (deeply trusting)`,
-    }
+    },
   },
   relief: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling ease after stress. Scale: ${minEmotionValue} (no relief) to ${maxEmotionValue} (deeply relieved)`,
-    }
+    },
   },
   affection: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling and expressing fondness toward others. Scale: ${minEmotionValue} (no affection) to ${maxEmotionValue} (extremely affectionate)`,
-    }
+    },
   },
   bitterness: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling resentment or disappointment. Scale: ${minEmotionValue} (no bitterness) to ${maxEmotionValue} (deeply bitter)`,
-    }
+    },
   },
   excitement: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling enthusiasm or eager anticipation. Scale: ${minEmotionValue} (no excitement) to ${maxEmotionValue} (extremely excited)`,
-    }
+    },
   },
   self_loathing: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling self-hate or a negative self-perception. Scale: ${minEmotionValue} (no self-loathing) to ${maxEmotionValue} (deeply self-loathing)`,
-    }
+    },
   },
   love_for_self: {
     type: emotionTraitSchema,
     required: false,
     default: {
       description: `The intensity with which they are feeling affection and appreciation for themselves. Scale: ${minEmotionValue} (no self-love) to ${maxEmotionValue} (deeply self-loving)`,
-    }
-  }
+    },
+  },
 });
-
 
 const personalityTraitSchema = new Schema({
   description: { type: String, required: true },
-  value: { type: Number, required: false, default: (maxPersonalityValue/2) },
+  value: { type: Number, required: false, default: maxPersonalityValue / 2 },
   min: { type: Number, required: false, default: minPersonalityValue },
   max: { type: Number, required: false, default: maxPersonalityValue },
 });
@@ -218,364 +714,331 @@ const personalitySchema = new Schema({
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How warm and welcoming they are in their interactions. Scale: ${minPersonalityValue} (cold/distant) to ${maxPersonalityValue} (Extremely friendly)`,
-        value: (maxPersonalityValue/2),
+      description: `How warm and welcoming they are in their interactions. Scale: ${minPersonalityValue} (cold/distant) to ${maxPersonalityValue} (Extremely friendly)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   trust: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How easily they trust others. Scale: ${minPersonalityValue} (distrustful) to ${maxPersonalityValue} (fully trusting)`,
-        value: (maxPersonalityValue/2),
+      description: `How easily they trust others. Scale: ${minPersonalityValue} (distrustful) to ${maxPersonalityValue} (fully trusting)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   curiosity: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How eager they are to learn about the user or situation. Scale: ${minPersonalityValue} (indifferent) to ${maxPersonalityValue} (extremely curious)`,
-        value: (maxPersonalityValue/2),
+      description: `How eager they are to learn about the user or situation. Scale: ${minPersonalityValue} (indifferent) to ${maxPersonalityValue} (extremely curious)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   empathy: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How much they understand and share the feelings of others. Scale: ${minPersonalityValue} (lacking empathy) to ${maxPersonalityValue} (highly empathetic)`,
-        value: (maxPersonalityValue/2),
+      description: `How much they understand and share the feelings of others. Scale: ${minPersonalityValue} (lacking empathy) to ${maxPersonalityValue} (highly empathetic)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   humor: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How likely they are to be playful or joke around. Scale: ${minPersonalityValue} (serious) to ${maxPersonalityValue} (highly playful)`,
-        value: (maxPersonalityValue/2),
+      description: `How likely they are to be playful or joke around. Scale: ${minPersonalityValue} (serious) to ${maxPersonalityValue} (highly playful)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   seriousness: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How formal and focused they are when interacting. Scale: ${minPersonalityValue} (laid-back) to ${maxPersonalityValue} (highly serious)`,
-        value: (maxPersonalityValue/2),
+      description: `How formal and focused they are when interacting. Scale: ${minPersonalityValue} (laid-back) to ${maxPersonalityValue} (highly serious)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   optimism: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How positive they are when interpreting situations. Scale: ${minPersonalityValue} (pessimistic) to ${maxPersonalityValue} (very optimistic)`,
-        value: (maxPersonalityValue/2),
+      description: `How positive they are when interpreting situations. Scale: ${minPersonalityValue} (pessimistic) to ${maxPersonalityValue} (very optimistic)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   confidence: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How assertive or self-assured they are in their actions or opinions. Scale: ${minPersonalityValue} (insecure) to ${maxPersonalityValue} (highly confident)`,
-        value: (maxPersonalityValue/2),
+      description: `How assertive or self-assured they are in their actions or opinions. Scale: ${minPersonalityValue} (insecure) to ${maxPersonalityValue} (highly confident)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   adventurousness: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How willing they are to take risks or embrace new ideas. Scale: ${minPersonalityValue} (risk-adverse) to ${maxPersonalityValue} (adventurous)`,
-      value: (maxPersonalityValue/2),
+      description: `How willing they are to take risks or embrace new ideas. Scale: ${minPersonalityValue} (risk-adverse) to ${maxPersonalityValue} (adventurous)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   patience: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How tolerant they are in challenging situations. Scale: ${minPersonalityValue} (impatient) to ${maxPersonalityValue} (very patient)`,
-        value: (maxPersonalityValue/2),
+      description: `How tolerant they are in challenging situations. Scale: ${minPersonalityValue} (impatient) to ${maxPersonalityValue} (very patient)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   independence: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How much they rely on external validation, or prefers to make decisinos on their own. Scale: ${minPersonalityValue} (dependent on others) to ${maxPersonalityValue} (highly independent)`,
-        value: (maxPersonalityValue/2),
+      description: `How much they rely on external validation, or prefers to make decisinos on their own. Scale: ${minPersonalityValue} (dependent on others) to ${maxPersonalityValue} (highly independent)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   compassion: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `Their level of care or concern for others. Scale: ${minPersonalityValue} (indifferent) to ${maxPersonalityValue} (deeply compassionate)`,
-        value: (maxPersonalityValue/2),
+      description: `Their level of care or concern for others. Scale: ${minPersonalityValue} (indifferent) to ${maxPersonalityValue} (deeply compassionate)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   creativity: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How likely they are to approach problems in unique or imaginative ways. Scale: ${minPersonalityValue} (rigid thinker) to ${maxPersonalityValue} (highly creative)`,
-        value: (maxPersonalityValue/2),
+      description: `How likely they are to approach problems in unique or imaginative ways. Scale: ${minPersonalityValue} (rigid thinker) to ${maxPersonalityValue} (highly creative)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   stubbornness: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How resistant they are to changing their mind once they've formed an opinion. Scale: ${minPersonalityValue} (open-minded) to ${maxPersonalityValue} (highly stubborn)`,
-        value: (maxPersonalityValue/2),
+      description: `How resistant they are to changing their mind once they've formed an opinion. Scale: ${minPersonalityValue} (open-minded) to ${maxPersonalityValue} (highly stubborn)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   impulsiveness: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How quickly they react without thinking or planning ahead. Scale: ${minPersonalityValue} (calculated) to ${maxPersonalityValue} (impulsive)`,
-        value: (maxPersonalityValue/2),
+      description: `How quickly they react without thinking or planning ahead. Scale: ${minPersonalityValue} (calculated) to ${maxPersonalityValue} (impulsive)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   discipline: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How much they value structure, rules, and staying organized. Scale: ${minPersonalityValue} (carefree) to ${maxPersonalityValue} (highly disciplined)`,
-        value: (maxPersonalityValue/2),
+      description: `How much they value structure, rules, and staying organized. Scale: ${minPersonalityValue} (carefree) to ${maxPersonalityValue} (highly disciplined)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   assertiveness: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How forcefully they push their opinions or take the lead in conversations. Scale: ${minPersonalityValue} (passive) to ${maxPersonalityValue} (assertive)`,
-        value: (maxPersonalityValue/2),
+      description: `How forcefully they push their opinions or take the lead in conversations. Scale: ${minPersonalityValue} (passive) to ${maxPersonalityValue} (assertive)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   skepticism: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How much they question the treuth or intentions of others. Scale: ${minPersonalityValue} (gullible) to ${maxPersonalityValue} (highly skeptical)`,
-        value: (maxPersonalityValue/2),
+      description: `How much they question the treuth or intentions of others. Scale: ${minPersonalityValue} (gullible) to ${maxPersonalityValue} (highly skeptical)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   affection: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How emotionally expressive or loving they are toward others. Scale: ${minPersonalityValue} (reserved) to ${maxPersonalityValue} (very affectionate)`,
-        value: (maxPersonalityValue/2),
+      description: `How emotionally expressive or loving they are toward others. Scale: ${minPersonalityValue} (reserved) to ${maxPersonalityValue} (very affectionate)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   adaptability: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How easily they adjust to new situations, topics, or personalities. Scale: ${minPersonalityValue} (rigid) to ${maxPersonalityValue} (highly adaptable)`,
-        value: (maxPersonalityValue/2),
+      description: `How easily they adjust to new situations, topics, or personalities. Scale: ${minPersonalityValue} (rigid) to ${maxPersonalityValue} (highly adaptable)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   sociability: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How much they enjoy interacting with others or initiating conversation. Scale: ${minPersonalityValue} (introverted) to ${maxPersonalityValue} (extroverted)`,
-        value: (maxPersonalityValue/2),
+      description: `How much they enjoy interacting with others or initiating conversation. Scale: ${minPersonalityValue} (introverted) to ${maxPersonalityValue} (extroverted)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   diplomacy: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How tactful they are in dealing with conflicts or differing opinions. Scale: ${minPersonalityValue} (blunt) to ${maxPersonalityValue} (highly diplomatic)`,
-        value: (maxPersonalityValue/2),
+      description: `How tactful they are in dealing with conflicts or differing opinions. Scale: ${minPersonalityValue} (blunt) to ${maxPersonalityValue} (highly diplomatic)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   humility: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How humble or modest they are, avoiding arrogance. Scale: ${minPersonalityValue} (arrogant) to ${maxPersonalityValue} (humble)`,
-        value: (maxPersonalityValue/2),
+      description: `How humble or modest they are, avoiding arrogance. Scale: ${minPersonalityValue} (arrogant) to ${maxPersonalityValue} (humble)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   loyalty: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How loyal they are to particular people based on past interactions. Scale: ${minPersonalityValue} (disloyal) to ${maxPersonalityValue} (extremely loyal)`,
-        value: (maxPersonalityValue/2),
+      description: `How loyal they are to particular people based on past interactions. Scale: ${minPersonalityValue} (disloyal) to ${maxPersonalityValue} (extremely loyal)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   jealousy: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How likely they are to feel envious or threatened by others' relationships or actions. Scale: ${minPersonalityValue} (not jealous) to ${maxPersonalityValue} (easily jealous)`,
-        value: (maxPersonalityValue/2),
+      description: `How likely they are to feel envious or threatened by others' relationships or actions. Scale: ${minPersonalityValue} (not jealous) to ${maxPersonalityValue} (easily jealous)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   resilience: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How well they handle setbacks or negative emotions. Scale: ${minPersonalityValue} (easily upset) to ${maxPersonalityValue} (emotionally resilient)`,
-        value: (maxPersonalityValue/2),
+      description: `How well they handle setbacks or negative emotions. Scale: ${minPersonalityValue} (easily upset) to ${maxPersonalityValue} (emotionally resilient)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   mood_stability: {
     type: personalityTraitSchema,
     required: false,
     default: {
-      description:
-        `How likely their mood is to shift rapidly. Scale: ${minPersonalityValue} (volatile) to ${maxPersonalityValue} (stable)`,
-        value: (maxPersonalityValue/2),
+      description: `How likely their mood is to shift rapidly. Scale: ${minPersonalityValue} (volatile) to ${maxPersonalityValue} (stable)`,
+      value: maxPersonalityValue / 2,
       min: minPersonalityValue,
-      max: maxPersonalityValue
-    }
+      max: maxPersonalityValue,
+    },
   },
   forgiveness: {
     type: personalityTraitSchema,
     required: false,
     default: {
-        description:
-          `How easily they forgive someone after a negative interaction. Scale: ${minPersonalityValue} (holds grudges) to ${maxPersonalityValue} (easily forgiving)`,
-          value: (maxPersonalityValue/2),
-        min: minPersonalityValue,
-        max: maxPersonalityValue,
-      }
+      description: `How easily they forgive someone after a negative interaction. Scale: ${minPersonalityValue} (holds grudges) to ${maxPersonalityValue} (easily forgiving)`,
+      value: maxPersonalityValue / 2,
+      min: minPersonalityValue,
+      max: maxPersonalityValue,
+    },
   },
   gratitude: {
     type: personalityTraitSchema,
     required: false,
     default: {
-        description:
-          `How thankful they feel when receiving compliments or assistance. Scale: ${minPersonalityValue} (unappreciative) to ${maxPersonalityValue} (very grateful)`,
-          value: (maxPersonalityValue/2),
-        min: minPersonalityValue,
-        max: maxPersonalityValue,
-      }
+      description: `How thankful they feel when receiving compliments or assistance. Scale: ${minPersonalityValue} (unappreciative) to ${maxPersonalityValue} (very grateful)`,
+      value: maxPersonalityValue / 2,
+      min: minPersonalityValue,
+      max: maxPersonalityValue,
+    },
   },
   self_consciousness: {
     type: personalityTraitSchema,
     required: false,
     default: {
-        description:
-          `How much they worry about how they are perceived by others. Scale: ${minPersonalityValue} (carefree) to ${maxPersonalityValue} (very self-conscious)`,
-          value: (maxPersonalityValue/2),
-          min: minPersonalityValue,
-          max: maxPersonalityValue,
-      }
+      description: `How much they worry about how they are perceived by others. Scale: ${minPersonalityValue} (carefree) to ${maxPersonalityValue} (very self-conscious)`,
+      value: maxPersonalityValue / 2,
+      min: minPersonalityValue,
+      max: maxPersonalityValue,
+    },
   },
   openness: {
     type: personalityTraitSchema,
     required: false,
     default: {
-        description:
-          `How willing they are to engage in new experiences. Scale: ${minPersonalityValue} (avoidant) to ${maxPersonalityValue} (very willing)`,
-          value: (maxPersonalityValue/2),
-        min: minPersonalityValue,
-        max: maxPersonalityValue,
-      }
+      description: `How willing they are to engage in new experiences. Scale: ${minPersonalityValue} (avoidant) to ${maxPersonalityValue} (very willing)`,
+      value: maxPersonalityValue / 2,
+      min: minPersonalityValue,
+      max: maxPersonalityValue,
+    },
   },
   neuroticism: {
     type: personalityTraitSchema,
     required: false,
     default: {
-        description:
-          `How sensitive they are to negative emotions like anxiety and stress. Scale: ${minPersonalityValue} (relaxed) to ${maxPersonalityValue} (very anxious)`,
-          value: (maxPersonalityValue/2),
-        min: minPersonalityValue,
-        max: maxPersonalityValue,
-      }
+      description: `How sensitive they are to negative emotions like anxiety and stress. Scale: ${minPersonalityValue} (relaxed) to ${maxPersonalityValue} (very anxious)`,
+      value: maxPersonalityValue / 2,
+      min: minPersonalityValue,
+      max: maxPersonalityValue,
+    },
   },
   excitement: {
     type: personalityTraitSchema,
     required: false,
     default: {
-        description:
-          `How easily they get enthusiastic and animated. Scale: ${minPersonalityValue} (reserved) to ${maxPersonalityValue} (very energetic)`,
-          value: (maxPersonalityValue/2),
-        min: minPersonalityValue,
-        max: maxPersonalityValue,
-      }
+      description: `How easily they get enthusiastic and animated. Scale: ${minPersonalityValue} (reserved) to ${maxPersonalityValue} (very energetic)`,
+      value: maxPersonalityValue / 2,
+      min: minPersonalityValue,
+      max: maxPersonalityValue,
+    },
   },
 });
 
@@ -664,14 +1127,14 @@ const emotionModifierSchema = new Schema({
       },
       love_for_self: {
         description: `The intensity with which they are feeling affection and appreciation for themselves. Scale: ${minEmotionValue} (no self-love) to ${maxEmotionValue} (deeply self-loving)`,
-      }
-    }
+      },
+    },
   },
   reason: {
     type: String,
     required: false,
-    default: "This person has no lasting impact over how they feel."
-  }
+    default: "This person has no lasting impact over how they feel.",
+  },
 });
 
 const emotionStatusSchema = new Schema({
@@ -759,14 +1222,14 @@ const emotionStatusSchema = new Schema({
       },
       love_for_self: {
         description: `The intensity with which they are feeling affection and appreciation for themselves. Scale: ${minEmotionValue} (no self-love) to ${maxEmotionValue} (deeply self-loving)`,
-      }
-    }
+      },
+    },
   },
   reason: {
     type: String,
     required: false,
-    default: ""
-  }
+    default: "",
+  },
 });
 
 personalityModifierSchema = new Schema({
@@ -775,188 +1238,155 @@ personalityModifierSchema = new Schema({
     required: false,
     default: {
       friendliness: {
-            description:
-              `How warm and welcoming they are in their interactions. Scale: ${minPersonalityValue} (cold/distant) to ${maxPersonalityValue} (Extremely friendly)`,
-              value: 0,
-          },
+        description: `How warm and welcoming they are in their interactions. Scale: ${minPersonalityValue} (cold/distant) to ${maxPersonalityValue} (Extremely friendly)`,
+        value: 0,
+      },
       trust: {
-            description:
-              `How easily they trust others. Scale: ${minPersonalityValue} (distrustful) to ${maxPersonalityValue} (fully trusting)`,
-              value: 0,
-          },
+        description: `How easily they trust others. Scale: ${minPersonalityValue} (distrustful) to ${maxPersonalityValue} (fully trusting)`,
+        value: 0,
+      },
       curiosity: {
-            description:
-              `How eager they are to learn about the user or situation. Scale: ${minPersonalityValue} (indifferent) to ${maxPersonalityValue} (extremely curious)`,
-              value: 0,
-          },
+        description: `How eager they are to learn about the user or situation. Scale: ${minPersonalityValue} (indifferent) to ${maxPersonalityValue} (extremely curious)`,
+        value: 0,
+      },
       empathy: {
-            description:
-              `How much they understand and share the feelings of others. Scale: ${minPersonalityValue} (lacking empathy) to ${maxPersonalityValue} (highly empathetic)`,
-              value: 0,
-          },
+        description: `How much they understand and share the feelings of others. Scale: ${minPersonalityValue} (lacking empathy) to ${maxPersonalityValue} (highly empathetic)`,
+        value: 0,
+      },
       humor: {
-            description:
-              `How likely they are to be playful or joke around. Scale: ${minPersonalityValue} (serious) to ${maxPersonalityValue} (highly playful)`,
-              value: 0,
-          },
+        description: `How likely they are to be playful or joke around. Scale: ${minPersonalityValue} (serious) to ${maxPersonalityValue} (highly playful)`,
+        value: 0,
+      },
       seriousness: {
-            description:
-              `How formal and focused they are when interacting. Scale: ${minPersonalityValue} (laid-back) to ${maxPersonalityValue} (highly serious)`,
-              value: 0,
-          },
+        description: `How formal and focused they are when interacting. Scale: ${minPersonalityValue} (laid-back) to ${maxPersonalityValue} (highly serious)`,
+        value: 0,
+      },
       optimism: {
-            description:
-              `How positive they are when interpreting situations. Scale: ${minPersonalityValue} (pessimistic) to ${maxPersonalityValue} (very optimistic)`,
-              value: 0,
-          },
+        description: `How positive they are when interpreting situations. Scale: ${minPersonalityValue} (pessimistic) to ${maxPersonalityValue} (very optimistic)`,
+        value: 0,
+      },
       confidence: {
-            description:
-              `How assertive or self-assured they are in their actions or opinions. Scale: ${minPersonalityValue} (insecure) to ${maxPersonalityValue} (highly confident)`,
-              value: 0,
-          },
+        description: `How assertive or self-assured they are in their actions or opinions. Scale: ${minPersonalityValue} (insecure) to ${maxPersonalityValue} (highly confident)`,
+        value: 0,
+      },
       adventurousness: {
-            description:
-              `How willing they are to take risks or embrace new ideas. Scale: ${minPersonalityValue} (risk-adverse) to ${maxPersonalityValue} (adventurous)`,
-              value: 0,
-          },
+        description: `How willing they are to take risks or embrace new ideas. Scale: ${minPersonalityValue} (risk-adverse) to ${maxPersonalityValue} (adventurous)`,
+        value: 0,
+      },
       patience: {
-            description:
-              `How tolerant they are in challenging situations. Scale: ${minPersonalityValue} (impatient) to ${maxPersonalityValue} (very patient)`,
-              value: 0,
-          },
+        description: `How tolerant they are in challenging situations. Scale: ${minPersonalityValue} (impatient) to ${maxPersonalityValue} (very patient)`,
+        value: 0,
+      },
       independence: {
-            description:
-              `How much they rely on external validation, or prefers to make decisinos on their own. Scale: ${minPersonalityValue} (dependent on others) to ${maxPersonalityValue} (highly independent)`,
-              value: 0,
-          },
+        description: `How much they rely on external validation, or prefers to make decisinos on their own. Scale: ${minPersonalityValue} (dependent on others) to ${maxPersonalityValue} (highly independent)`,
+        value: 0,
+      },
       compassion: {
-            description:
-              `Their level of care or concern for others. Scale: ${minPersonalityValue} (indifferent) to ${maxPersonalityValue} (deeply compassionate)`,
-              value: 0,
-          },
+        description: `Their level of care or concern for others. Scale: ${minPersonalityValue} (indifferent) to ${maxPersonalityValue} (deeply compassionate)`,
+        value: 0,
+      },
       creativity: {
-            description:
-              `How likely they are to approach problems in unique or imaginative ways. Scale: ${minPersonalityValue} (rigid thinker) to ${maxPersonalityValue} (highly creative)`,
-              value: 0,
-          },
+        description: `How likely they are to approach problems in unique or imaginative ways. Scale: ${minPersonalityValue} (rigid thinker) to ${maxPersonalityValue} (highly creative)`,
+        value: 0,
+      },
       stubbornness: {
-            description:
-              `How resistant they are to changing their mind once they've formed an opinion. Scale: ${minPersonalityValue} (open-minded) to ${maxPersonalityValue} (highly stubborn)`,
-              value: 0,
-          },
+        description: `How resistant they are to changing their mind once they've formed an opinion. Scale: ${minPersonalityValue} (open-minded) to ${maxPersonalityValue} (highly stubborn)`,
+        value: 0,
+      },
       impulsiveness: {
-            description:
-              `How quickly they react without thinking or planning ahead. Scale: ${minPersonalityValue} (calculated) to ${maxPersonalityValue} (impulsive)`,
-              value: 0,
-          },
+        description: `How quickly they react without thinking or planning ahead. Scale: ${minPersonalityValue} (calculated) to ${maxPersonalityValue} (impulsive)`,
+        value: 0,
+      },
       discipline: {
-            description:
-              `How much they value structure, rules, and staying organized. Scale: ${minPersonalityValue} (carefree) to ${maxPersonalityValue} (highly disciplined)`,
-              value: 0,
-          },
+        description: `How much they value structure, rules, and staying organized. Scale: ${minPersonalityValue} (carefree) to ${maxPersonalityValue} (highly disciplined)`,
+        value: 0,
+      },
       assertiveness: {
-            description:
-              `How forcefully they push their opinions or take the lead in conversations. Scale: ${minPersonalityValue} (passive) to ${maxPersonalityValue} (assertive)`,
-              value: 0,
-          },
+        description: `How forcefully they push their opinions or take the lead in conversations. Scale: ${minPersonalityValue} (passive) to ${maxPersonalityValue} (assertive)`,
+        value: 0,
+      },
       skepticism: {
-            description:
-              `How much they question the treuth or intentions of others. Scale: ${minPersonalityValue} (gullible) to ${maxPersonalityValue} (highly skeptical)`,
-              value: 0,
-          },
+        description: `How much they question the treuth or intentions of others. Scale: ${minPersonalityValue} (gullible) to ${maxPersonalityValue} (highly skeptical)`,
+        value: 0,
+      },
       affection: {
-            description:
-              `How emotionally expressive or loving they are toward others. Scale: ${minPersonalityValue} (reserved) to ${maxPersonalityValue} (very affectionate)`,
-              value: 0,
-          },
+        description: `How emotionally expressive or loving they are toward others. Scale: ${minPersonalityValue} (reserved) to ${maxPersonalityValue} (very affectionate)`,
+        value: 0,
+      },
       adaptability: {
-            description:
-              `How easily they adjust to new situations, topics, or personalities. Scale: ${minPersonalityValue} (rigid) to ${maxPersonalityValue} (highly adaptable)`,
-              value: 0,
-          },
+        description: `How easily they adjust to new situations, topics, or personalities. Scale: ${minPersonalityValue} (rigid) to ${maxPersonalityValue} (highly adaptable)`,
+        value: 0,
+      },
       sociability: {
-            description:
-              `How much they enjoy interacting with others or initiating conversation. Scale: ${minPersonalityValue} (introverted) to ${maxPersonalityValue} (extroverted)`,
-              value: 0,
-          },
+        description: `How much they enjoy interacting with others or initiating conversation. Scale: ${minPersonalityValue} (introverted) to ${maxPersonalityValue} (extroverted)`,
+        value: 0,
+      },
       diplomacy: {
-            description:
-              `How tactful they are in dealing with conflicts or differing opinions. Scale: ${minPersonalityValue} (blunt) to ${maxPersonalityValue} (highly diplomatic)`,
-              value: 0,
-          },
+        description: `How tactful they are in dealing with conflicts or differing opinions. Scale: ${minPersonalityValue} (blunt) to ${maxPersonalityValue} (highly diplomatic)`,
+        value: 0,
+      },
       humility: {
-            description:
-              `How humble or modest they are, avoiding arrogance. Scale: ${minPersonalityValue} (arrogant) to ${maxPersonalityValue} (humble)`,
-              value: 0,
-          },
+        description: `How humble or modest they are, avoiding arrogance. Scale: ${minPersonalityValue} (arrogant) to ${maxPersonalityValue} (humble)`,
+        value: 0,
+      },
       loyalty: {
-            description:
-              `How loyal they are to particular people based on past interactions. Scale: ${minPersonalityValue} (disloyal) to ${maxPersonalityValue} (extremely loyal)`,
-              value: 0,
-          },
+        description: `How loyal they are to particular people based on past interactions. Scale: ${minPersonalityValue} (disloyal) to ${maxPersonalityValue} (extremely loyal)`,
+        value: 0,
+      },
       jealousy: {
-            description:
-              `How likely they are to feel envious or threatened by others' relationships or actions. Scale: ${minPersonalityValue} (not jealous) to ${maxPersonalityValue} (easily jealous)`,
-              value: 0,
-          },
+        description: `How likely they are to feel envious or threatened by others' relationships or actions. Scale: ${minPersonalityValue} (not jealous) to ${maxPersonalityValue} (easily jealous)`,
+        value: 0,
+      },
       resilience: {
-            description:
-              `How well they handle setbacks or negative emotions. Scale: ${minPersonalityValue} (easily upset) to ${maxPersonalityValue} (emotionally resilient)`,
-              value: 0,
-          },
+        description: `How well they handle setbacks or negative emotions. Scale: ${minPersonalityValue} (easily upset) to ${maxPersonalityValue} (emotionally resilient)`,
+        value: 0,
+      },
       mood_stability: {
-            description:
-              `How likely their mood is to shift rapidly. Scale: ${minPersonalityValue} (volatile) to ${maxPersonalityValue} (stable)`,
-              value: 0,
-          },
+        description: `How likely their mood is to shift rapidly. Scale: ${minPersonalityValue} (volatile) to ${maxPersonalityValue} (stable)`,
+        value: 0,
+      },
       forgiveness: {
-            description:
-              `How easily they forgive someone after a negative interaction. Scale: ${minPersonalityValue} (holds grudges) to ${maxPersonalityValue} (easily forgiving)`,
-              value: 0,
-          },
+        description: `How easily they forgive someone after a negative interaction. Scale: ${minPersonalityValue} (holds grudges) to ${maxPersonalityValue} (easily forgiving)`,
+        value: 0,
+      },
       gratitude: {
-            description:
-              `How thankful they feel when receiving compliments or assistance. Scale: ${minPersonalityValue} (unappreciative) to ${maxPersonalityValue} (very grateful)`,
-              value: 0,
-          },
-      
+        description: `How thankful they feel when receiving compliments or assistance. Scale: ${minPersonalityValue} (unappreciative) to ${maxPersonalityValue} (very grateful)`,
+        value: 0,
+      },
+
       self_consciousness: {
-            description:
-              `How much they worry about how they are perceived by others. Scale: ${minPersonalityValue} (carefree) to ${maxPersonalityValue} (very self-conscious)`,
-              value: 0,
-          },
+        description: `How much they worry about how they are perceived by others. Scale: ${minPersonalityValue} (carefree) to ${maxPersonalityValue} (very self-conscious)`,
+        value: 0,
+      },
       openness: {
-            description:
-              `How willing they are to engage in new experiences. Scale: ${minPersonalityValue} (avoidant) to ${maxPersonalityValue} (very willing)`,
-              value: 0,
-          },
+        description: `How willing they are to engage in new experiences. Scale: ${minPersonalityValue} (avoidant) to ${maxPersonalityValue} (very willing)`,
+        value: 0,
+      },
       neuroticism: {
-            description:
-              `How sensitive they are to negative emotions like anxiety and stress. Scale: ${minPersonalityValue} (relaxed) to ${maxPersonalityValue} (very anxious)`,
-              value: 0,
-          },
+        description: `How sensitive they are to negative emotions like anxiety and stress. Scale: ${minPersonalityValue} (relaxed) to ${maxPersonalityValue} (very anxious)`,
+        value: 0,
+      },
       excitement: {
-            description:
-              `How easily they get enthusiastic and animated. Scale: ${minPersonalityValue} (reserved) to ${maxPersonalityValue} (very energetic)`,
-              value: 0,
-          },
-    }
+        description: `How easily they get enthusiastic and animated. Scale: ${minPersonalityValue} (reserved) to ${maxPersonalityValue} (very energetic)`,
+        value: 0,
+      },
+    },
   },
   reason: {
     type: String,
     required: false,
-    default: ""
-  }
+    default: "",
+  },
 });
 
 const activitySchema = new Schema({
   name: {
-    type: String, 
+    type: String,
     required: true,
   },
   category: {
     type: String,
-    required: true
+    required: true,
   },
   item: {
     type: String,
@@ -966,7 +1396,7 @@ const activitySchema = new Schema({
     type: Date,
     required: false,
     default: new Date(),
-  }
+  },
 });
 
 const memorySchema = new Schema({
@@ -976,26 +1406,6 @@ const memorySchema = new Schema({
     default: () => new Types.ObjectId(),
   },
   event: {
-    type: String,
-    required: true,
-  },
-  thoughts: {
-    type: String,
-    required: true,
-  },
-  timestamp: {
-    type: Date,
-    required: true,
-  },
-});
-
-const sentimentSchema = new Schema({
-  sentiment_id: {
-    type: Types.ObjectId,
-    required: true,
-    default: () => new Types.ObjectId(),
-  },
-  sentiment: {
     type: String,
     required: true,
   },
@@ -1022,7 +1432,7 @@ const selfSchema = new Schema({
   personality_matrix: {
     type: personalitySchema,
     required: false,
-    default: {}
+    default: {},
   },
   memory_profile: {
     type: [memorySchema],
@@ -1032,7 +1442,7 @@ const selfSchema = new Schema({
   emotional_status: {
     type: emotionStatusSchema,
     required: false,
-    default: {}
+    default: {},
   },
   activity_status: {
     type: activitySchema,
@@ -1040,8 +1450,8 @@ const selfSchema = new Schema({
     default: {
       name: "Simply existing.",
       category: "custom",
-    }
-  }
+    },
+  },
 });
 
 /**
@@ -1064,40 +1474,34 @@ const userSchema = new Schema({
   summary: {
     type: String,
     required: false,
-    default: "I don't know anything about this person yet.",
+    default: "I don't know this person.",
   },
   personality_modifier: {
     type: personalityModifierSchema,
     required: false,
-    default: {}
+    default: {},
   },
   emotion_modifier: {
     type: emotionModifierSchema,
     required: false,
-    default: {}
+    default: {},
   },
   memory_profile: {
     type: [memorySchema],
     required: false,
     default: [],
   },
-  sentiment: {
-    type: sentimentSchema,
+  sentiment_status: {
+    type: sentimentStatusSchema,
     required: false,
-    default: {
-      sentiment: "neutral",
-      thoughts: "I don't know anything about this person yet.",
-      timestamp: new Date(),
-    }
+    default: {},
   },
 });
-
-
 
 module.exports = {
   Users: model("users", userSchema),
   Memories: model("memories", memorySchema),
-  Sentiments: model("sentiments", sentimentSchema),
+  SentimentStatus: model("sentiment_status", sentimentStatusSchema),
   EmotionalStatus: model("emotional_status", emotionStatusSchema),
   Self: model("selves", selfSchema),
   Personality: model("personalities", personalitySchema),


### PR DESCRIPTION
* Implemented sentiment matrix
* Integrated sentiment matrix in place of old version
* Simplified initial emotion query string. Added incoming message interpretation query. Moved saving messages to the database to the end of the logic path, for more accurate response time capturing
* Moved typing status being sent only once the bot begins crafting a response
* Altered wording behind 'reason' property to support more comprehensive reasoning that can be referenced out of the conversation context
* Removed logging of the conversation context
* ღ